### PR TITLE
fix: generalize feature alignment in customer_score for universal model inference parity 

### DIFF
--- a/src/score.py
+++ b/src/score.py
@@ -309,15 +309,9 @@ def score_customers(df, feature_cols, model_path, model_name,
 
     X = df[feature_cols].copy()
 
-    # XGBoost requires feature names in exact training order
-    # Reorder to match training feature sequence if needed
-    try:
-        booster_features = model.get_booster().feature_names
-        if booster_features is not None:
-            X = X[booster_features]
-    except AttributeError:
-        # Not an XGBoost model — logistic regression doesn't need this
-        pass
+    # Align features to the exact schema/order the model was trained on.
+    # This ensures CustomerID is dropped and features are in the correct order for sklearn/XGBoost.
+    X = X[model.feature_names_in_]
 
     proba = model.predict_proba(X)[:, 1]
     prediction = (proba >= threshold).astype(int)


### PR DESCRIPTION
**This PR resolves the ValueError encountered when running score.py with the Logistic Regression pipeline (Closes #3).**

**Bug Source:** 
Turns out the feature ordering was mis-matched not the selection. Fix is the same either way. 

**Changes:**
1. Removed model-specific conditional checks in score_customers.
2. Implemented explicit feature reindexing using model.feature_names_in_.

**Rationale:**
The score.py script must be dynamic and allow for variable model fitting setups from different notebooks. By enforcing alignment at inference time, the pipeline is now model-agnostic.