### PR TITLE
feat: diagnose filtered records and quantify cancellation signal

### DIFF
--- a/notebooks/01_eda.ipynb
+++ b/notebooks/01_eda.ipynb
@@ -32,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 10,
    "id": "881da881-bc4e-416c-96d8-25645d3df9b8",
    "metadata": {},
    "outputs": [
@@ -153,7 +153,7 @@
        "4 2009-12-01 07:45:00   1.25      13085.0  United Kingdom  "
       ]
      },
-     "execution_count": 14,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -197,7 +197,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 11,
    "id": "c06774f9-c34e-4b1d-b8ed-b77d8262941a",
    "metadata": {},
    "outputs": [
@@ -321,7 +321,7 @@
        "4 2009-12-01 07:45:00   1.25       13085  United Kingdom     30.0  "
       ]
      },
-     "execution_count": 15,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -367,146 +367,119 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "354f9c72",
+   "metadata": {},
+   "source": [
+    "## Diagnosing Filtered Records"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 16,
-   "id": "31e0ca6f-5657-403b-a497-77d63ee1445f",
+   "execution_count": 13,
+   "id": "cb203491",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Orders table shape: (19213, 7)\n"
+      "Total raw rows:              525,461\n",
+      "Null Customer ID:            107,927\n",
+      "Cancellations (C-prefix):    10,206\n",
+      "Non-positive quantity:       12,326\n",
+      "Zero/negative price:         3,690\n",
+      "\n",
+      "--- Overlap ---\n",
+      "Null ID + cancellation:      367\n",
+      "Null ID + non-pos qty:       2,487\n",
+      "Cancel + non-pos qty:        10,205\n",
+      "All three:                   366\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>Customer ID</th>\n",
-       "      <th>Invoice</th>\n",
-       "      <th>order_ts</th>\n",
-       "      <th>total_revenue</th>\n",
-       "      <th>total_qty</th>\n",
-       "      <th>n_items</th>\n",
-       "      <th>n_lines</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>12346</td>\n",
-       "      <td>491725</td>\n",
-       "      <td>2009-12-14 08:34:00</td>\n",
-       "      <td>45.0</td>\n",
-       "      <td>10</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>12346</td>\n",
-       "      <td>491742</td>\n",
-       "      <td>2009-12-14 11:00:00</td>\n",
-       "      <td>22.5</td>\n",
-       "      <td>5</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>12346</td>\n",
-       "      <td>491744</td>\n",
-       "      <td>2009-12-14 11:02:00</td>\n",
-       "      <td>22.5</td>\n",
-       "      <td>5</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>12346</td>\n",
-       "      <td>492718</td>\n",
-       "      <td>2009-12-18 10:47:00</td>\n",
-       "      <td>22.5</td>\n",
-       "      <td>5</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>12346</td>\n",
-       "      <td>492722</td>\n",
-       "      <td>2009-12-18 10:55:00</td>\n",
-       "      <td>1.0</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "  Customer ID Invoice            order_ts  total_revenue  total_qty  n_items  \\\n",
-       "0       12346  491725 2009-12-14 08:34:00           45.0         10        1   \n",
-       "1       12346  491742 2009-12-14 11:00:00           22.5          5        1   \n",
-       "2       12346  491744 2009-12-14 11:02:00           22.5          5        1   \n",
-       "3       12346  492718 2009-12-18 10:47:00           22.5          5        1   \n",
-       "4       12346  492722 2009-12-18 10:55:00            1.0          1        1   \n",
-       "\n",
-       "   n_lines  \n",
-       "0        1  \n",
-       "1        1  \n",
-       "2        1  \n",
-       "3        1  \n",
-       "4        1  "
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
     }
    ],
    "source": [
     "# ─────────────────────────────────────────────────────────────\n",
-    "# Order-Level Table Construction\n",
-    "# Aggregate line-item transactions to one row per order,\n",
-    "# computing total revenue, quantity, and item diversity\n",
+    "# Quantify Excluded Records\n",
+    "# Break down the ~118k filtered rows by exclusion reason\n",
+    "# to assess whether we're discarding useful signal.\n",
     "# ─────────────────────────────────────────────────────────────\n",
     "\n",
-    "orders = (\n",
-    "    df_clean\n",
-    "    .groupby([\"Customer ID\", \"Invoice\"])\n",
-    "    .agg(\n",
-    "        order_ts      =(\"InvoiceDate\",  \"min\"),\n",
-    "        total_revenue =(\"Revenue\",      \"sum\"),\n",
-    "        total_qty     =(\"Quantity\",     \"sum\"),\n",
-    "        n_items       =(\"StockCode\", \"nunique\"),\n",
-    "        n_lines       =(\"StockCode\",   \"size\"),\n",
-    "    )\n",
-    "    .reset_index()\n",
-    ")\n",
+    "# Reload raw data for comparison (df is already in memory from earlier)\n",
+    "null_id    = df[\"Customer ID\"].isna()\n",
+    "cancel     = df[\"Invoice\"].astype(str).str.startswith(\"C\")\n",
+    "non_pos_qty = df[\"Quantity\"] <= 0\n",
+    "zero_price = df[\"Price\"] <= 0\n",
     "\n",
-    "print(\"Orders table shape:\", orders.shape)\n",
-    "orders.head()"
+    "print(f\"Total raw rows:              {len(df):,}\")\n",
+    "print(f\"Null Customer ID:            {null_id.sum():,}\")\n",
+    "print(f\"Cancellations (C-prefix):    {cancel.sum():,}\")\n",
+    "print(f\"Non-positive quantity:       {non_pos_qty.sum():,}\")\n",
+    "print(f\"Zero/negative price:         {zero_price.sum():,}\")\n",
+    "print(f\"\\n--- Overlap ---\")\n",
+    "print(f\"Null ID + cancellation:      {(null_id & cancel).sum():,}\")\n",
+    "print(f\"Null ID + non-pos qty:       {(null_id & non_pos_qty).sum():,}\")\n",
+    "print(f\"Cancel + non-pos qty:        {(cancel & non_pos_qty).sum():,}\")\n",
+    "print(f\"All three:                   {(null_id & cancel & non_pos_qty).sum():,}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "c230cfef",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(0, 8)\n",
+      "Customer ID\n",
+      "True    2121\n",
+      "Name: count, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(df[non_pos_qty & ~cancel & ~null_id].shape)\n",
+    "print(df[non_pos_qty & ~cancel][\"Customer ID\"].isna().value_counts())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "eaf1dad1",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Gross purchase customers:      4,312\n",
+      "Customers with cancellations:  1,798\n",
+      "\n",
+      "--- Overlap with gross customers ---\n",
+      "Cancel customers in gross set: 1,729 (96.2%)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ─────────────────────────────────────────────────────────────\n",
+    "# Customer Overlap: Who is cancelling?\n",
+    "# ─────────────────────────────────────────────────────────────\n",
+    "\n",
+    "# Identifiable cancellations (have a Customer ID + C-prefix)\n",
+    "id_cancel = df[cancel & ~null_id]\n",
+    "\n",
+    "# Current gross purchase customers\n",
+    "gross_customers = set(df_clean[\"Customer ID\"].unique())\n",
+    "cancel_customers = set(id_cancel[\"Customer ID\"].astype(int).astype(str).unique())\n",
+    "\n",
+    "print(f\"Gross purchase customers:      {len(gross_customers):,}\")\n",
+    "print(f\"Customers with cancellations:  {len(cancel_customers):,}\")\n",
+    "print(f\"\\n--- Overlap with gross customers ---\")\n",
+    "print(f\"Cancel customers in gross set: {len(cancel_customers & gross_customers):,} \"\n",
+    "      f\"({len(cancel_customers & gross_customers)/len(cancel_customers):.1%})\")"
    ]
   },
   {
@@ -717,7 +690,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },


### PR DESCRIPTION
PR explores currently filtered records due to null Customer ID, Cancellations, and Returns (Closes #10 ). Summary of changes made to 01 notebook: 

- Added filtered data diagnostic section code 
- added visualizations to exploratory analysis sections 

Next, order-level table must be restructured to include cancellation signal